### PR TITLE
Add HTML/PDF report generation

### DIFF
--- a/insight.py
+++ b/insight.py
@@ -16,6 +16,7 @@ from modules.header_analyzer import header_analyzer
 from modules.crawler import crawl_and_analyze
 from modules.summary import print_summary
 from modules.print_status import print_status
+from modules.reporting import generate_html_report, generate_pdf_report
 
 
 def main():
@@ -69,6 +70,8 @@ def main():
     )
     parser.add_argument("-c", "--crawl-depth", type=int, default=2, help="Crawling depth")
     parser.add_argument("-o", "--output", help="Output file for results")
+    parser.add_argument("--html-report", help="Write HTML summary to FILE")
+    parser.add_argument("--pdf-report", help="Write PDF summary to FILE")
 
     args = parser.parse_args()
 
@@ -118,6 +121,14 @@ def main():
         with open(args.output, "w") as f:
             json.dump(results, f, indent=2)
         print_status(f"Results saved to {args.output}", "success")
+
+    if args.html_report:
+        generate_html_report(results, args.html_report)
+        print_status(f"HTML report saved to {args.html_report}", "success")
+
+    if args.pdf_report:
+        generate_pdf_report(results, args.pdf_report)
+        print_status(f"PDF report saved to {args.pdf_report}", "success")
 
 
 if __name__ == "__main__":

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -1,1 +1,1 @@
-
+from .reporting import generate_html_report, generate_pdf_report

--- a/modules/reporting.py
+++ b/modules/reporting.py
@@ -1,0 +1,75 @@
+from jinja2 import Environment, select_autoescape
+import json
+
+
+def _calculate_summary(results):
+    """Return summary counts similar to print_summary."""
+    critical = 0
+    warning = 0
+    info = 0
+    for module, data in results.get("modules", {}).items():
+        if module == "ssl_analyzer":
+            if any("vulnerable" in str(item).lower() for item in data):
+                critical += 1
+        elif module == "header_analyzer":
+            if any("MISSING" in str(item) for item in data):
+                warning += 1
+        elif module == "crawler" and data:
+            critical += len(data)
+    return {"critical": critical, "warning": warning, "info": info}
+
+
+def _render_html(results):
+    """Render HTML report from results."""
+    env = Environment(autoescape=select_autoescape(["html", "xml"]))
+    template_str = """
+    <!DOCTYPE html>
+    <html>
+    <head>
+        <meta charset='utf-8'>
+        <title>Insight Report - {{ results.target }}</title>
+        <style>
+            body { font-family: Arial, sans-serif; margin: 20px; }
+            h1 { background: #333; color: #fff; padding: 10px; }
+            table { border-collapse: collapse; width: 100%; margin-bottom: 20px; }
+            th, td { border: 1px solid #ccc; padding: 8px; text-align: left; }
+            th { background: #f2f2f2; }
+            pre { background: #f8f8f8; padding: 10px; border: 1px solid #eee; }
+        </style>
+    </head>
+    <body>
+        <h1>Insight Scan Report</h1>
+        <p><strong>Target:</strong> {{ results.target }}</p>
+        <p><strong>Date:</strong> {{ results.timestamp }}</p>
+        <h2>Summary</h2>
+        <table>
+            <tr><th>Critical Findings</th><th>Warnings</th><th>Informational</th></tr>
+            <tr><td>{{ summary.critical }}</td><td>{{ summary.warning }}</td><td>{{ summary.info }}</td></tr>
+        </table>
+        <h2>Module Results</h2>
+        {% for name, data in modules %}
+        <h3>{{ name }}</h3>
+        <pre>{{ data }}</pre>
+        {% endfor %}
+    </body>
+    </html>
+    """
+    template = env.from_string(template_str)
+    summary = _calculate_summary(results)
+    modules = [(name, json.dumps(data, indent=2)) for name, data in results.get("modules", {}).items()]
+    return template.render(results=results, summary=summary, modules=modules)
+
+
+def generate_html_report(results, outfile):
+    """Write HTML report to outfile."""
+    html = _render_html(results)
+    with open(outfile, "w") as f:
+        f.write(html)
+
+
+def generate_pdf_report(results, outfile):
+    """Write PDF report to outfile using weasyprint."""
+    from weasyprint import HTML
+
+    html = _render_html(results)
+    HTML(string=html).write_pdf(outfile)

--- a/readme.md
+++ b/readme.md
@@ -64,7 +64,8 @@ pip install insight-pentest
   -p 80 443 8080 \
   -e .php .bak .old \
   -c 3 \
-  -o report.json
+  -o report.json \
+  --html-report report.html
 ```
 
 ### Command Options
@@ -78,6 +79,8 @@ pip install insight-pentest
 | `-t THREADS` | Maximum threads | 30 |
 | `-c DEPTH` | Crawling depth | 2 |
 | `-o FILE` | JSON output file | |
+| `--html-report FILE` | Save HTML summary report | |
+| `--pdf-report FILE` | Save PDF summary report | |
 
 ## Modules Overview
 


### PR DESCRIPTION
## Summary
- generate HTML summary and optional PDF report
- add `--html-report` and `--pdf-report` flags
- document new output options

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `python3 insight.py -u example.com -p 80 --crawl-depth 0 --threads 1 --html-report test.html --pdf-report test.pdf -o test.json` *(fails: network access to example.com blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6867d6502f74832689dcd30ed40a60d7