### PR TITLE
Add YAML config option

### DIFF
--- a/examples/config.yml
+++ b/examples/config.yml
@@ -1,0 +1,12 @@
+# Example configuration file for Insight
+url: https://target.com
+# Wordlist paths
+dir_wordlist: wordlists/dirs.txt
+sub_wordlist: wordlists/subdomains.txt
+# Ports to scan
+ports: [80, 443, 8080]
+# Optional file extensions for directory brute forcing
+extensions: ["", ".php", ".bak"]
+threads: 30
+crawl_depth: 2
+output: results.json

--- a/insight.py
+++ b/insight.py
@@ -6,6 +6,7 @@ import sys
 import time
 from urllib.parse import urlparse
 from datetime import datetime
+import yaml
 
 from modules.colors import BANNER
 from modules.directory_bruteforce import directory_bruteforce
@@ -20,57 +21,113 @@ from modules.print_status import print_status
 
 def main():
     print(BANNER)
+
+    # Parse optional configuration file first
+    config_parser = argparse.ArgumentParser(add_help=False)
+    config_parser.add_argument("--config", help="YAML configuration file")
+    config_args, remaining = config_parser.parse_known_args()
+
+    config = {}
+    if config_args.config:
+        try:
+            with open(config_args.config) as f:
+                config = yaml.safe_load(f) or {}
+            print_status(f"Loaded configuration from {config_args.config}", "info")
+        except FileNotFoundError:
+            print_status(f"Config file not found: {config_args.config}", "error")
+            sys.exit(1)
+        except yaml.YAMLError as e:
+            print_status(f"Invalid config file: {e}", "error")
+            sys.exit(1)
+
     parser = argparse.ArgumentParser(
         description="Insight Web Pentesting Framework",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        parents=[config_parser],
     )
-    parser.add_argument("-u", "--url", required=True, help="Target URL")
-    parser.add_argument("-d", "--dir-wordlist", help="Directory brute-force wordlist")
-    parser.add_argument("-s", "--sub-wordlist", help="Subdomain enumeration wordlist")
+    parser.add_argument(
+        "-u",
+        "--url",
+        required=not config.get("url"),
+        default=config.get("url"),
+        help="Target URL",
+    )
+    parser.add_argument(
+        "-d",
+        "--dir-wordlist",
+        default=config.get("dir_wordlist"),
+        help="Directory brute-force wordlist",
+    )
+    parser.add_argument(
+        "-s",
+        "--sub-wordlist",
+        default=config.get("sub_wordlist"),
+        help="Subdomain enumeration wordlist",
+    )
     parser.add_argument(
         "-p",
         "--ports",
         nargs="+",
         type=int,
-        default=[
-            21,
-            22,
-            23,
-            25,
-            53,
-            80,
-            110,
-            143,
-            443,
-            445,
-            993,
-            995,
-            1433,
-            3306,
-            3389,
-            5432,
-            5900,
-            6379,
-            8000,
-            8080,
-            8443,
-            9000,
-            27017,
-        ],
+        default=config.get(
+            "ports",
+            [
+                21,
+                22,
+                23,
+                25,
+                53,
+                80,
+                110,
+                143,
+                443,
+                445,
+                993,
+                995,
+                1433,
+                3306,
+                3389,
+                5432,
+                5900,
+                6379,
+                8000,
+                8080,
+                8443,
+                9000,
+                27017,
+            ],
+        ),
         help="Ports to scan",
     )
-    parser.add_argument("-t", "--threads", type=int, default=30, help="Max threads")
+    parser.add_argument(
+        "-t",
+        "--threads",
+        type=int,
+        default=config.get("threads", 30),
+        help="Max threads",
+    )
     parser.add_argument(
         "-e",
         "--extensions",
         nargs="+",
-        default=["", ".php", ".html", ".txt", ".bak", ".old", ".zip"],
+        default=config.get("extensions", ["", ".php", ".html", ".txt", ".bak", ".old", ".zip"]),
         help="File extensions for brute-force",
     )
-    parser.add_argument("-c", "--crawl-depth", type=int, default=2, help="Crawling depth")
-    parser.add_argument("-o", "--output", help="Output file for results")
+    parser.add_argument(
+        "-c",
+        "--crawl-depth",
+        type=int,
+        default=config.get("crawl_depth", 2),
+        help="Crawling depth",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        default=config.get("output"),
+        help="Output file for results",
+    )
 
-    args = parser.parse_args()
+    args = parser.parse_args(remaining)
 
     if not args.url.startswith("http"):
         args.url = "http://" + args.url


### PR DESCRIPTION
## Summary
- allow loading a YAML config via `--config`
- map config values to existing CLI options
- provide example config file

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6867d649942c8326882f8436b7597280