### PR TITLE
Add tests and pytest configuration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests
+pytest

--- a/tests/test_header_analyzer.py
+++ b/tests/test_header_analyzer.py
@@ -1,0 +1,35 @@
+import os, sys; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import pytest
+
+from modules import header_analyzer as ha
+
+class MockResponse:
+    def __init__(self, headers):
+        self.headers = headers
+
+
+def test_header_analyzer_detects_headers(monkeypatch):
+    sample_headers = {
+        'Content-Security-Policy': 'default-src self',
+        'X-Content-Type-Options': 'nosniff',
+        'X-Frame-Options': 'DENY'
+    }
+
+    def mock_get(url, headers=None, timeout=5):
+        return MockResponse(sample_headers)
+
+    monkeypatch.setattr(ha, 'animated_progress_bar', lambda *a, **k: None)
+    monkeypatch.setattr(ha, 'print_table', lambda *a, **k: None)
+    monkeypatch.setattr(ha, 'print_status', lambda *a, **k: None)
+    monkeypatch.setattr(ha, 'get_random_ua', lambda: 'UA')
+    monkeypatch.setattr(ha.requests, 'get', mock_get)
+
+    results = ha.header_analyzer('http://example.com')
+    result_map = {h: (status, value) for h, status, value in results}
+
+    assert 'Content-Security-Policy' in result_map
+    assert 'PRESENT' in result_map['Content-Security-Policy'][0]
+    assert result_map['Content-Security-Policy'][1] == 'default-src self'
+
+    assert 'Strict-Transport-Security' in result_map
+    assert 'MISSING' in result_map['Strict-Transport-Security'][0]

--- a/tests/test_random_ua.py
+++ b/tests/test_random_ua.py
@@ -1,0 +1,14 @@
+import os, sys; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from modules.random_ua import get_random_ua
+
+EXPECTED_UAS = [
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.1 Safari/605.1.15",
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.107 Safari/537.36",
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 14_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.1 Mobile/15E148 Safari/604.1",
+    "Mozilla/5.0 (Windows NT 10.0; rv:78.0) Gecko/20100101 Firefox/78.0",
+]
+
+def test_get_random_ua_returns_known_agent():
+    ua = get_random_ua()
+    assert ua in EXPECTED_UAS


### PR DESCRIPTION
## Summary
- add `requirements.txt` with pytest and requests
- create tests for `header_analyzer` using mocked requests
- add test for `get_random_ua`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867d646dd3c83268234baa4eda81f30