### PR TITLE
Fix CLI options in insight

### DIFF
--- a/insight.py
+++ b/insight.py
@@ -21,6 +21,7 @@ from modules.summary import print_summary
 
 from modules.print_status import print_status
 from modules.plugin_loader import load_plugins
+from modules import generate_html_report, generate_pdf_report
 
 
 
@@ -132,6 +133,22 @@ def main():
         "--output",
         default=config.get("output"),
         help="Output file for results",
+    )
+    parser.add_argument(
+        "--log-level",
+        default=config.get("log_level", "INFO"),
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        help="Logging verbosity",
+    )
+    parser.add_argument(
+        "--html-report",
+        default=config.get("html_report"),
+        help="Write HTML report to file",
+    )
+    parser.add_argument(
+        "--pdf-report",
+        default=config.get("pdf_report"),
+        help="Write PDF report to file",
     )
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 pytest
 aiohttp>=3.8.0
 requests>=2.28.0
+jinja2>=3.0
 
 


### PR DESCRIPTION
## Summary
- import reporting helpers
- add CLI flags for log level and HTML/PDF reports

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6867dde2601c8326863883361960f82b