### PR TITLE
Add robots.txt checker plugin and AI agent module

### DIFF
--- a/modules/ai_agent.py
+++ b/modules/ai_agent.py
@@ -1,0 +1,28 @@
+"""Simple AI agent that performs weighted-sum predictions.
+
+The agent expects a path to a JSON file containing a list of weights.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import List, Sequence
+
+
+class AIAgent:
+    """Load model weights and run predictions using a weighted sum."""
+
+    def __init__(self, weights_path: str) -> None:
+        self.weights = self._load_weights(weights_path)
+
+    def _load_weights(self, path: str) -> List[float]:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        if not isinstance(data, list):
+            raise ValueError("Weights file must contain a list of numbers")
+        return [float(w) for w in data]
+
+    def predict(self, inputs: Sequence[float]) -> float:
+        if len(inputs) != len(self.weights):
+            raise ValueError("Input length must match number of weights")
+        return sum(w * x for w, x in zip(self.weights, inputs))

--- a/plugins/robots_checker.py
+++ b/plugins/robots_checker.py
@@ -1,0 +1,25 @@
+import requests
+from modules.print_status import print_status
+from modules.random_ua import get_random_ua
+
+
+def run(target):
+    """Fetch and parse robots.txt for disallowed paths"""
+    url = target.rstrip('/') + '/robots.txt'
+    try:
+        response = requests.get(url, headers={"User-Agent": get_random_ua()}, timeout=5)
+        if response.status_code != 200:
+            print_status(f"No robots.txt found at {url}", "warning")
+            return {"found": False, "disallow": []}
+        disallow = []
+        for line in response.text.splitlines():
+            line = line.strip()
+            if line.lower().startswith('disallow:'):
+                path = line.split(':', 1)[1].strip()
+                if path:
+                    disallow.append(path)
+        print_status(f"Found robots.txt with {len(disallow)} disallowed entries", "success")
+        return {"found": True, "disallow": disallow}
+    except Exception as e:
+        print_status(f"Failed to fetch robots.txt: {e}", "error")
+        return {"found": False, "disallow": []}

--- a/tests/test_ai_agent.py
+++ b/tests/test_ai_agent.py
@@ -1,0 +1,27 @@
+import os, sys, json, tempfile, pytest; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from modules.ai_agent import AIAgent
+
+
+def test_ai_agent_predict():
+    weights = [0.5, 1.5, -1.0]
+    with tempfile.NamedTemporaryFile("w", delete=False) as fh:
+        json.dump(weights, fh)
+        path = fh.name
+    try:
+        agent = AIAgent(path)
+        assert agent.predict([2, 2, 2]) == pytest.approx(2.0)
+    finally:
+        os.remove(path)
+
+
+def test_ai_agent_mismatched_input():
+    weights = [1.0, 2.0]
+    with tempfile.NamedTemporaryFile("w", delete=False) as fh:
+        json.dump(weights, fh)
+        path = fh.name
+    try:
+        agent = AIAgent(path)
+        with pytest.raises(ValueError):
+            agent.predict([1.0])
+    finally:
+        os.remove(path)

--- a/tests/test_robots_checker.py
+++ b/tests/test_robots_checker.py
@@ -1,0 +1,20 @@
+import os, sys; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import plugins.robots_checker as rc
+
+class MockResponse:
+    def __init__(self, text, status_code=200):
+        self.text = text
+        self.status_code = status_code
+
+
+def test_robots_checker_parses_disallow(monkeypatch):
+    data = "User-agent: *\nDisallow: /admin\nDisallow: /private\n"
+    def mock_get(url, headers=None, timeout=5):
+        return MockResponse(data, 200)
+    monkeypatch.setattr(rc, 'print_status', lambda *a, **k: None)
+    monkeypatch.setattr(rc, 'get_random_ua', lambda: 'UA')
+    monkeypatch.setattr(rc.requests, 'get', mock_get)
+    result = rc.run('https://example.com')
+    assert result['found'] is True
+    assert '/admin' in result['disallow']
+    assert '/private' in result['disallow']


### PR DESCRIPTION
## Summary
- extend plugin suite with `robots_checker` to parse target `robots.txt`
- test robots checker plugin for disallow path extraction
- introduce `AIAgent` module that loads weights from JSON for simple predictions
- add tests ensuring AI agent uses weights correctly and validates input length

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2c9e2c7288326857bae38835079cf