### PR TITLE
Add Comprehensive Test Suite and Fix SSL Analyzer Bug

### DIFF
--- a/modules/ssl_analyzer.py
+++ b/modules/ssl_analyzer.py
@@ -34,7 +34,7 @@ def ssl_analyzer(target):
                 subject = dict(x[0] for x in cert['subject'])['commonName']
 
                 vulns = []
-                if "TLSv1" in tls_version:
+                if tls_version == "TLSv1":
                     vulns.append("TLSv1 (POODLE vulnerable)")
                 if "RC4" in cipher[0]:
                     vulns.append("RC4 cipher (weak)")

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1,0 +1,77 @@
+import os
+import sys
+import pytest
+import requests
+from unittest.mock import MagicMock
+
+# Add the root directory to sys.path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from modules.crawler import crawl_and_analyze
+
+class MockResponse:
+    def __init__(self, text, url="http://example.com"):
+        self.text = text
+        self.url = url
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+def test_crawler_finds_vulnerabilities(monkeypatch):
+    # Mock responses for different URLs
+    def mock_get(url, **kwargs):
+        if url == "http://example.com":
+            return MockResponse('<html><body><a href="/vulnerable">Link</a></body></html>', url)
+        if url == "http://example.com/vulnerable":
+            return MockResponse('<html><body>Potential SQL Injection: select * from users;</body></html>', url)
+        return MockResponse('Not found', url)
+
+    monkeypatch.setattr(requests, "get", mock_get)
+
+    # Mock UI functions and sleep
+    import modules.crawler as crawler
+    monkeypatch.setattr(crawler, 'animated_progress_bar', lambda *a, **k: None)
+    monkeypatch.setattr(crawler, 'print_status', lambda *a, **k: None)
+    monkeypatch.setattr(crawler, 'print_table', lambda *a, **k: None)
+    monkeypatch.setattr(crawler, 'sleep', lambda x: None)
+
+    results = crawl_and_analyze("http://example.com", depth=1)
+
+    assert len(results) == 1
+    assert results[0][2] == "SQL Injection"
+    assert "vulnerable" in results[0][1]
+
+def test_crawler_finds_xss_in_url(monkeypatch):
+    target = "http://example.com/?q=<script>alert(1)</script>"
+
+    def mock_get(url, **kwargs):
+        return MockResponse('<html><body>No vuln in body</body></html>', url)
+
+    monkeypatch.setattr(requests, "get", mock_get)
+
+    import modules.crawler as crawler
+    monkeypatch.setattr(crawler, 'animated_progress_bar', lambda *a, **k: None)
+    monkeypatch.setattr(crawler, 'print_status', lambda *a, **k: None)
+    monkeypatch.setattr(crawler, 'print_table', lambda *a, **k: None)
+    monkeypatch.setattr(crawler, 'sleep', lambda x: None)
+
+    results = crawl_and_analyze(target, depth=0)
+
+    assert any(r[2] == "XSS Vulnerability" for r in results)
+
+def test_crawler_handles_request_exception(monkeypatch):
+    def mock_get(url, **kwargs):
+        raise requests.RequestException("Connection error")
+
+    monkeypatch.setattr(requests, "get", mock_get)
+
+    import modules.crawler as crawler
+    monkeypatch.setattr(crawler, 'animated_progress_bar', lambda *a, **k: None)
+    monkeypatch.setattr(crawler, 'print_status', lambda *a, **k: None)
+    monkeypatch.setattr(crawler, 'sleep', lambda x: None)
+
+    results = crawl_and_analyze("http://example.com", depth=0)
+    assert results == []

--- a/tests/test_directory_bruteforce.py
+++ b/tests/test_directory_bruteforce.py
@@ -1,0 +1,82 @@
+import os
+import sys
+import pytest
+import aiohttp
+
+# Add the root directory to sys.path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from modules.directory_bruteforce import directory_bruteforce
+
+class MockAsyncResponse:
+    def __init__(self, status, data=b""):
+        self.status = status
+        self.data = data
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+    async def read(self):
+        return self.data
+
+def test_directory_bruteforce_finds_paths(monkeypatch, tmp_path):
+    # Create a temporary wordlist
+    wordlist_file = tmp_path / "wordlist.txt"
+    wordlist_file.write_text("admin\nconfig\nsecret")
+
+    # Mock aiohttp.ClientSession.get
+    def mock_get(self, url, **kwargs):
+        if "admin" in url:
+            return MockAsyncResponse(200, b"Found admin")
+        if "config" in url:
+            return MockAsyncResponse(200, b"Found config")
+        return MockAsyncResponse(404)
+
+    monkeypatch.setattr(aiohttp.ClientSession, "get", mock_get)
+
+    # Mock status printing and progress bar to keep output clean
+    import modules.directory_bruteforce as db
+    monkeypatch.setattr(db, 'print_status', lambda *a, **k: None)
+    monkeypatch.setattr(sys.stdout, 'write', lambda *a, **k: None)
+    monkeypatch.setattr(sys.stdout, 'flush', lambda *a, **k: None)
+
+    results = directory_bruteforce("http://target.com", str(wordlist_file), extensions=[""])
+
+    # Verify results
+    assert len(results) == 2
+    found_urls = [r[0] for r in results]
+    assert "http://target.com/admin" in found_urls
+    assert "http://target.com/config" in found_urls
+    assert "http://target.com/secret" not in found_urls
+
+def test_directory_bruteforce_with_extensions(monkeypatch, tmp_path):
+    wordlist_file = tmp_path / "wordlist.txt"
+    wordlist_file.write_text("index")
+
+    def mock_get(self, url, **kwargs):
+        if "index.php" in url:
+            return MockAsyncResponse(200, b"index.php")
+        return MockAsyncResponse(404)
+
+    monkeypatch.setattr(aiohttp.ClientSession, "get", mock_get)
+
+    import modules.directory_bruteforce as db
+    monkeypatch.setattr(db, 'print_status', lambda *a, **k: None)
+    monkeypatch.setattr(sys.stdout, 'write', lambda *a, **k: None)
+    monkeypatch.setattr(sys.stdout, 'flush', lambda *a, **k: None)
+
+    results = directory_bruteforce("http://target.com", str(wordlist_file), extensions=[".php", ".html"])
+
+    assert len(results) == 1
+    assert results[0][0] == "http://target.com/index.php"
+    assert results[0][1] == 200
+
+def test_directory_bruteforce_file_not_found(monkeypatch):
+    import modules.directory_bruteforce as db
+    monkeypatch.setattr(db, 'print_status', lambda *a, **k: None)
+
+    results = directory_bruteforce("http://target.com", "nonexistent.txt")
+    assert results == []

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -1,0 +1,65 @@
+import os
+import sys
+import pkgutil
+import importlib
+import pytest
+from unittest.mock import MagicMock, patch
+
+# Add the root directory to sys.path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from modules.plugin_loader import load_plugins
+
+def test_load_plugins_success(monkeypatch):
+    # Mock pkgutil.iter_modules
+    def mock_iter_modules(path):
+        return [(None, "test_plugin", False)]
+    monkeypatch.setattr(pkgutil, "iter_modules", mock_iter_modules)
+
+    # Mock importlib.import_module
+    mock_module = MagicMock()
+    mock_module.run = lambda x: {"status": "ok"}
+    mock_module.__name__ = "plugins.test_plugin"
+
+    def mock_import_module(name):
+        if name == "plugins.test_plugin":
+            return mock_module
+        raise ImportError()
+    monkeypatch.setattr(importlib, "import_module", mock_import_module)
+
+    # Mock os.path.exists and Path.exists
+    from pathlib import Path
+    monkeypatch.setattr(Path, "exists", lambda self: True)
+
+    # Mock print_status
+    import modules.plugin_loader as pl
+    monkeypatch.setattr(pl, 'print_status', lambda *a, **k: None)
+
+    plugins = load_plugins()
+
+    assert len(plugins) == 1
+    assert plugins[0].run("test") == {"status": "ok"}
+
+def test_load_plugins_missing_run(monkeypatch):
+    def mock_iter_modules(path):
+        return [(None, "bad_plugin", False)]
+    monkeypatch.setattr(pkgutil, "iter_modules", mock_iter_modules)
+
+    mock_module = MagicMock(spec=[]) # No run attribute
+    monkeypatch.setattr(importlib, "import_module", lambda name: mock_module)
+
+    from pathlib import Path
+    monkeypatch.setattr(Path, "exists", lambda self: True)
+
+    import modules.plugin_loader as pl
+    monkeypatch.setattr(pl, 'print_status', lambda *a, **k: None)
+
+    plugins = load_plugins()
+    assert len(plugins) == 0
+
+def test_load_plugins_dir_not_found(monkeypatch):
+    from pathlib import Path
+    monkeypatch.setattr(Path, "exists", lambda self: False)
+
+    plugins = load_plugins("nonexistent")
+    assert plugins == []

--- a/tests/test_port_scan.py
+++ b/tests/test_port_scan.py
@@ -1,0 +1,63 @@
+import os
+import sys
+import asyncio
+import pytest
+from unittest.mock import MagicMock
+
+# Add the root directory to sys.path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from modules.port_scan import port_scan
+from unittest.mock import AsyncMock
+
+def test_port_scan_finds_open_ports(monkeypatch):
+    # Mock status printing and progress bar
+    import modules.port_scan as ps
+    monkeypatch.setattr(ps, 'print_status', lambda *a, **k: None)
+    monkeypatch.setattr(sys.stdout, 'write', lambda *a, **k: None)
+    monkeypatch.setattr(sys.stdout, 'flush', lambda *a, **k: None)
+
+    # Mock asyncio.open_connection on the module itself
+    async def mock_open_connection(host, port):
+        if port in [80, 443]:
+            reader = MagicMock()
+            writer = MagicMock()
+            writer.wait_closed = AsyncMock()
+            return reader, writer
+        else:
+            raise ConnectionRefusedError()
+
+    monkeypatch.setattr(ps.asyncio, "open_connection", mock_open_connection)
+
+    results = port_scan("http://example.com", [21, 80, 443, 8080])
+
+    assert len(results) == 2
+    ports = [r[0] for r in results]
+    assert 80 in ports
+    assert 443 in ports
+    assert 21 not in ports
+
+    # Check services
+    service_map = dict(results)
+    assert service_map[80] == "HTTP"
+    assert service_map[443] == "HTTPS"
+
+def test_port_scan_handles_unknown_services(monkeypatch):
+    import modules.port_scan as ps
+    monkeypatch.setattr(ps, 'print_status', lambda *a, **k: None)
+    monkeypatch.setattr(sys.stdout, 'write', lambda *a, **k: None)
+    monkeypatch.setattr(sys.stdout, 'flush', lambda *a, **k: None)
+
+    async def mock_open_connection(host, port):
+        reader = MagicMock()
+        writer = MagicMock()
+        writer.wait_closed = AsyncMock()
+        return reader, writer
+
+    monkeypatch.setattr(ps.asyncio, "open_connection", mock_open_connection)
+    monkeypatch.setattr(sys.stdout, 'write', lambda *a, **k: None)
+    monkeypatch.setattr(sys.stdout, 'flush', lambda *a, **k: None)
+
+    results = port_scan("http://example.com", [12345])
+    assert len(results) == 1
+    assert results[0] == (12345, "Unknown")

--- a/tests/test_ssl_analyzer.py
+++ b/tests/test_ssl_analyzer.py
@@ -1,0 +1,99 @@
+import os
+import sys
+import socket
+import ssl
+import pytest
+from unittest.mock import MagicMock, patch
+
+# Add the root directory to sys.path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from modules.ssl_analyzer import ssl_analyzer
+
+def test_ssl_analyzer_success(monkeypatch):
+    # Mock certificate data
+    mock_cert = {
+        'notAfter': 'Jan 01 00:00:00 2030 GMT',
+        'issuer': ((('organizationName', 'Mock CA'),),),
+        'subject': ((('commonName', 'example.com'),),)
+    }
+
+    # Mock SSL context and socket
+    mock_ssock = MagicMock()
+    mock_ssock.getpeercert.return_value = mock_cert
+    mock_ssock.cipher.return_value = ('ECDHE-RSA-AES128-GCM-SHA256', 'TLSv1.3', 128)
+    mock_ssock.version.return_value = 'TLSv1.3'
+
+    # Context manager mock for ssock
+    mock_ssock.__enter__.return_value = mock_ssock
+
+    mock_context = MagicMock()
+    mock_context.wrap_socket.return_value = mock_ssock
+
+    monkeypatch.setattr(ssl, "create_default_context", lambda: mock_context)
+
+    # Mock socket.create_connection
+    mock_sock = MagicMock()
+    mock_sock.__enter__.return_value = mock_sock
+    monkeypatch.setattr(socket, "create_connection", lambda address: mock_sock)
+
+    # Mock UI functions
+    import modules.ssl_analyzer as sa
+    monkeypatch.setattr(sa, 'animated_progress_bar', lambda *a, **k: None)
+    monkeypatch.setattr(sa, 'print_table', lambda *a, **k: None)
+    monkeypatch.setattr(sa, 'print_status', lambda *a, **k: None)
+
+    results = ssl_analyzer("https://example.com")
+
+    assert len(results) > 0
+    result_dict = dict(results)
+    assert result_dict["Host"] == "example.com"
+    assert result_dict["Issuer"] == "Mock CA"
+    assert result_dict["Subject"] == "example.com"
+    assert result_dict["TLS Version"] == "TLSv1.3"
+    assert "None found" in result_dict["Vulnerabilities"]
+
+def test_ssl_analyzer_vulnerabilities(monkeypatch):
+    mock_cert = {
+        'notAfter': 'Jan 01 00:00:00 2020 GMT', # Expired
+        'issuer': ((('organizationName', 'Mock CA'),),),
+        'subject': ((('commonName', 'example.com'),),)
+    }
+
+    mock_ssock = MagicMock()
+    mock_ssock.getpeercert.return_value = mock_cert
+    mock_ssock.cipher.return_value = ('RC4-SHA', 'TLSv1', 128)
+    mock_ssock.version.return_value = 'TLSv1'
+    mock_ssock.__enter__.return_value = mock_ssock
+
+    mock_context = MagicMock()
+    mock_context.wrap_socket.return_value = mock_ssock
+
+    monkeypatch.setattr(ssl, "create_default_context", lambda: mock_context)
+
+    mock_sock = MagicMock()
+    mock_sock.__enter__.return_value = mock_sock
+    monkeypatch.setattr(socket, "create_connection", lambda address: mock_sock)
+
+    import modules.ssl_analyzer as sa
+    monkeypatch.setattr(sa, 'animated_progress_bar', lambda *a, **k: None)
+    monkeypatch.setattr(sa, 'print_table', lambda *a, **k: None)
+    monkeypatch.setattr(sa, 'print_status', lambda *a, **k: None)
+
+    results = ssl_analyzer("https://example.com")
+    result_dict = dict(results)
+
+    vulns = result_dict["Vulnerabilities"]
+    assert "POODLE" in vulns
+    assert "RC4" in vulns
+    assert "Expiring" in vulns
+
+def test_ssl_analyzer_failure(monkeypatch):
+    monkeypatch.setattr(socket, "create_connection", MagicMock(side_effect=Exception("Connection failed")))
+
+    import modules.ssl_analyzer as sa
+    monkeypatch.setattr(sa, 'animated_progress_bar', lambda *a, **k: None)
+    monkeypatch.setattr(sa, 'print_status', lambda *a, **k: None)
+
+    results = ssl_analyzer("https://example.com")
+    assert results == []

--- a/tests/test_subdomain_enumeration.py
+++ b/tests/test_subdomain_enumeration.py
@@ -1,0 +1,77 @@
+import os
+import sys
+import socket
+import asyncio
+import pytest
+
+# Add the root directory to sys.path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from modules.subdomain_enumeration import subdomain_enumeration
+
+def test_subdomain_enumeration_finds_subdomains(monkeypatch, tmp_path):
+    # Create a temporary wordlist
+    wordlist_file = tmp_path / "subdomains.txt"
+    wordlist_file.write_text("www\nmail\nnonexistent")
+
+    # Mock socket.getaddrinfo since loop.getaddrinfo usually calls it
+    def mock_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
+        if host == "www.example.com":
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, '', ("1.2.3.4", 0))]
+        if host == "mail.example.com":
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, '', ("5.6.7.8", 0))]
+        raise socket.gaierror(-2, "Name or service not known")
+
+    monkeypatch.setattr(socket, "getaddrinfo", mock_getaddrinfo)
+
+    # Mock socket.gethostbyname for wildcard check (simulate no wildcard)
+    def mock_gethostbyname(host):
+        raise socket.gaierror(-2, "Name or service not known")
+    monkeypatch.setattr(socket, "gethostbyname", mock_gethostbyname)
+
+    # Mock status printing and progress bar
+    import modules.subdomain_enumeration as se
+    monkeypatch.setattr(se, 'print_status', lambda *a, **k: None)
+    monkeypatch.setattr(sys.stdout, 'write', lambda *a, **k: None)
+    monkeypatch.setattr(sys.stdout, 'flush', lambda *a, **k: None)
+
+    results = subdomain_enumeration("example.com", str(wordlist_file))
+
+    assert len(results) == 2
+    assert ("www.example.com", "1.2.3.4") in results
+    assert ("mail.example.com", "5.6.7.8") in results
+
+def test_subdomain_enumeration_detects_wildcard(monkeypatch, tmp_path):
+    wordlist_file = tmp_path / "subdomains.txt"
+    wordlist_file.write_text("www")
+
+    # Mock wildcard detection
+    def mock_gethostbyname(host):
+        return "10.10.10.10"
+    monkeypatch.setattr(socket, "gethostbyname", mock_gethostbyname)
+
+    # Mock socket.getaddrinfo for actual enumeration
+    def mock_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, '', ("10.10.10.10", 0))]
+    monkeypatch.setattr(socket, "getaddrinfo", mock_getaddrinfo)
+
+    import modules.subdomain_enumeration as se
+    mocked_statuses = []
+    def mock_print_status(msg, status):
+        mocked_statuses.append((msg, status))
+    monkeypatch.setattr(se, 'print_status', mock_print_status)
+    monkeypatch.setattr(sys.stdout, 'write', lambda *a, **k: None)
+    monkeypatch.setattr(sys.stdout, 'flush', lambda *a, **k: None)
+
+    results = subdomain_enumeration("example.com", str(wordlist_file))
+
+    assert any("Wildcard DNS detected" in s[0] for s in mocked_statuses)
+    assert len(results) == 1
+    assert results[0] == ("www.example.com", "10.10.10.10")
+
+def test_subdomain_enumeration_file_not_found(monkeypatch):
+    import modules.subdomain_enumeration as se
+    monkeypatch.setattr(se, 'print_status', lambda *a, **k: None)
+
+    results = subdomain_enumeration("example.com", "nonexistent.txt")
+    assert results == []


### PR DESCRIPTION
I have added a comprehensive test suite to the Insight Web Pentesting Suite. This includes 17 new unit tests covering all major modules:

- **Crawler**: Verified vulnerability pattern detection in both content and URLs.
- **Directory Bruteforce**: Tested path discovery with and without extensions.
- **Plugin Loader**: Ensured plugins are correctly discovered and loaded.
- **Port Scan**: Verified open port detection and service mapping.
- **SSL Analyzer**: Added checks for certificate details and vulnerability detection.
- **Subdomain Enumeration**: Tested subdomain discovery and wildcard DNS detection.

During the process, I discovered and fixed a bug in the SSL analyzer where it would incorrectly flag TLS 1.2 and 1.3 as vulnerable to POODLE due to a substring match on "TLSv1".

All 32 tests now pass correctly.

---
*PR created automatically by Jules for task [13843417941663790323](https://jules.google.com/task/13843417941663790323) started by @Chalebgwa*